### PR TITLE
Adaptation 4.11

### DIFF
--- a/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.ClientBase/Company/Generated/DefaultCardView.xml
+++ b/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.ClientBase/Company/Generated/DefaultCardView.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+  <ViewName>Default</ViewName>
+</settings>

--- a/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.Server/Company/CompanyHandlers.cs
+++ b/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.Server/Company/CompanyHandlers.cs
@@ -7,6 +7,17 @@ using DirRX.ClearCPDuplicatesTemplate.Company;
 
 namespace DirRX.ClearCPDuplicatesTemplate
 {
+  partial class CompanyCreatingFromServerHandler
+  {
+
+    public override void CreatingFrom(Sungero.Domain.CreatingFromEventArgs e)
+    {
+      base.CreatingFrom(e);
+      e.Without(_info.Properties.OriginalCompanyDirRX);
+      e.Without(_info.Properties.DoubleStatusDirRX);      
+    }
+  }
+
   partial class CompanyOriginalCompanyDirRXPropertyFilteringServerHandler<T>
   {
 

--- a/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.Shared/Company/Company.mtd
+++ b/DirRX.ClearCPDuplicatesTemplate/DirRX.ClearCPDuplicatesTemplate.Shared/Company/Company.mtd
@@ -28,7 +28,7 @@
         {
           "$type": "Sungero.Metadata.ControlGroupMetadata, Sungero.Metadata",
           "NameGuid": "149a02cc-c0af-4bec-8a1b-8d6c0bab1d81",
-          "Name": "Counterparty",
+          "Name": "CounterpartyGroup",
           "ColumnDefinitions": [
             {
               "Percentage": 55.01
@@ -493,7 +493,8 @@
     }
   ],
   "HandledEvents": [
-    "BeforeSaveServer"
+    "BeforeSaveServer",
+    "CreatingFromServer"
   ],
   "IconResourcesKeys": [],
   "LayeredFromGuid": "593e143c-616c-4d95-9457-fd916c4aa7f8",


### PR DESCRIPTION
При копировании организации копировались и свойства "Оригинал организации" и "Статус обработки дублей". В результате свойства были заполнены, потенциально и, если это "оригинал", то не обрабатывались ФП. Исправлено.